### PR TITLE
Added read-only label to NodeList.length

### DIFF
--- a/files/en-us/web/api/nodelist/index.md
+++ b/files/en-us/web/api/nodelist/index.md
@@ -37,7 +37,7 @@ It's good to keep this distinction in mind when you choose how to iterate over t
 
 ## Instance properties
 
-- {{domxref("NodeList.length")}}
+- {{domxref("NodeList.length")}} {{ReadOnlyInline}}
   - : The number of nodes in the `NodeList`.
 
 ## Instance methods


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

I have added the label mentioned above.
<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I was looking at the documentation and noticed, that `NodeList.length` does not have a read-only label, which seemed odd. I have tried changing it and it is, in fact, read-only.
<!-- ❓ Why are you making these changes and how do they help readers? -->

